### PR TITLE
🎨 Palette: Improve descriptive link text and aria-labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-03-27 - [Descriptive Link Text]
 **Learning:** Using generic phrases like "here" (e.g., "see [here](url)") or "this publication" as link text creates a severe accessibility barrier for screen reader users, who frequently navigate by reading a list of links out of context. "Here" provides zero information about the link's destination or purpose.
 **Action:** Always write descriptive link text that explains the destination or purpose of the link (e.g., "see [the discussion on curve extension methods](url)"), rather than relying on the surrounding sentence for context.
+
+## 2026-03-29 - [Descriptive Text for Raw Links]
+**Learning:** Leaving raw URLs as links (e.g., `https://...`) forces screen readers to read out the entire URL string character by character, which is tedious and confusing. All links, even direct file downloads, should use descriptive text.
+**Action:** Always wrap raw URLs in descriptive text (e.g., `[Download Rhino 8.8](https://...)`) to provide context and a much better screen reader experience.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -100,7 +100,7 @@
 <!-- Announcement bar -->
 {% block announce %}
   For updates follow <strong>Eddy3D</strong> on
-  <a rel="me" href="https://www.linkedin.com/company/eddy3d-com">
+  <a rel="me" href="https://www.linkedin.com/company/eddy3d-com" aria-label="Follow Eddy3D on LinkedIn">
         <span class="twemoji linkedin" aria-hidden="true">
       {% include ".icons/fontawesome/brands/linkedin.svg" %}
     </span>

--- a/docs/publications.md
+++ b/docs/publications.md
@@ -6,7 +6,7 @@ hide:
 
 # Publications
 
-Publications related to Eddy3D are listed below, grouped by modules. See [Researchgate](https://www.researchgate.net/profile/Patrick-Kastner/research) for more info.
+Publications related to Eddy3D are listed below, grouped by modules. See [Patrick Kastner's ResearchGate profile](https://www.researchgate.net/profile/Patrick-Kastner/research) for more info.
 
 ## Outdoor+
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -288,8 +288,8 @@ Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Ed
 ### 0.4.15.0 (Jan 21, 2025)
 
 - Fixed: ***In Rhino 8.9 McNeel introduced a breaking change, see [the discussion on curve extension methods](https://discourse.mcneel.com/t/rhino-8-9-update-behavior-of-curve-extension-methods-changed/192560/5).*** If you upgraded to Rhino 8.9 already, below are links to downgrade to various versions Rhino 8.8:
-- https://files.mcneel.com/dujour/exe/20240618/rhino_en-us_8.8.24170.13001.exe
-- https://files.mcneel.com/dujour/exe/20240611/rhino_en-us_8.8.24163.12481.exe
+- [Download Rhino 8.8.24170.13001](https://files.mcneel.com/dujour/exe/20240618/rhino_en-us_8.8.24170.13001.exe)
+- [Download Rhino 8.8.24163.12481](https://files.mcneel.com/dujour/exe/20240611/rhino_en-us_8.8.24163.12481.exe)
 
 ### 0.4.8.0 (Mar 4, 2024)
 


### PR DESCRIPTION
**💡 What:** Replaced raw URLs with descriptive link text in the `versions.md` changelog, updated the "Researchgate" link to "Patrick Kastner's ResearchGate profile" in `publications.md`, and added an `aria-label` to the LinkedIn social icon link in the site header (`main.html`). I also added a new learning to `.Jules/palette.md` to avoid raw URLs.
**🎯 Why:** Generic link text or raw URLs create a severe accessibility barrier for screen reader users, forcing them to listen to entire URL strings or giving them no context when viewing a list of links. Adding `aria-label`s to purely iconic buttons gives screen reader users the necessary context.
**📸 Before/After:** N/A (Text and attributes changed, no visual UI differences).
**♿ Accessibility:** Greatly improved the context of hyperlinks for users utilizing assistive technologies like screen readers.

---
*PR created automatically by Jules for task [17324450140481334255](https://jules.google.com/task/17324450140481334255) started by @kastnerp*