### PR TITLE
🎨 Palette: Descriptive link text for raw URL in changelog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -48,3 +48,7 @@
 ## 2026-03-29 - [Descriptive Text for Raw Links]
 **Learning:** Leaving raw URLs as links (e.g., `https://...`) forces screen readers to read out the entire URL string character by character, which is tedious and confusing. All links, even direct file downloads, should use descriptive text.
 **Action:** Always wrap raw URLs in descriptive text (e.g., `[Download Rhino 8.8](https://...)`) to provide context and a much better screen reader experience.
+
+## 2026-03-30 - [Descriptive Link Text for Raw URLs]
+**Learning:** Found a raw URL used directly in the `versions.md` changelog. Raw URLs are highly inaccessible to screen reader users because the screen reader will read out every single character of the URL (e.g., "h t t p s colon slash slash..."), which provides poor context and is frustrating to listen to.
+**Action:** When adding URLs to documentation or changelogs, always wrap them in descriptive text, such as `[Eddy3D Visualizer](https://eddy3d-dev.github.io/Eddy3D-Visualizer/)`, so the screen reader announces a human-readable title.

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -183,7 +183,7 @@ Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Ed
 
 - Added:
 
-  A new visualiser interface at https://eddy3d-dev.github.io/Eddy3D-Visualizer/
+  A new visualiser interface at [Eddy3D Visualizer](https://eddy3d-dev.github.io/Eddy3D-Visualizer/)
 
 ### 0.4.16.815 (December 19, 2025)
 


### PR DESCRIPTION
💡 What: Replaced a raw URL in `docs/versions.md` with a descriptive markdown link (`[Eddy3D Visualizer](https://eddy3d-dev.github.io/Eddy3D-Visualizer/)`).
🎯 Why: Raw URLs are highly inaccessible to screen reader users because the screen reader will read out every single character of the URL (e.g., "h t t p s colon slash slash..."), which provides poor context and is frustrating to listen to. Using descriptive link text ensures the screen reader announces a human-readable title.
♿ Accessibility: Improved screen reader experience by providing context for the link.

---
*PR created automatically by Jules for task [11560858090730747712](https://jules.google.com/task/11560858090730747712) started by @kastnerp*