### PR TITLE
🎨 Palette: Add aria-hidden to decorative plus icon on homepage

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2026-03-30 - [Descriptive Link Text for Raw URLs]
 **Learning:** Found a raw URL used directly in the `versions.md` changelog. Raw URLs are highly inaccessible to screen reader users because the screen reader will read out every single character of the URL (e.g., "h t t p s colon slash slash..."), which provides poor context and is frustrating to listen to.
 **Action:** When adding URLs to documentation or changelogs, always wrap them in descriptive text, such as `[Eddy3D Visualizer](https://eddy3d-dev.github.io/Eddy3D-Visualizer/)`, so the screen reader announces a human-readable title.
+
+## 2026-04-01 - [Screen Reader Announcement of Decorative Emojis]
+**Learning:** In `docs/index.md`, there was a decorative plus sign (`:octicons-plus-24:`) between two logos. Emojis and icon fonts are often read aloud by screen readers (e.g., "plus"), which provides no value and creates a redundant, confusing experience when the element is purely for visual layout or decoration.
+**Action:** Always append `{ aria-hidden="true" }` to decorative emojis and icons (e.g., `:octicons-plus-24:{ aria-hidden="true" }`) to explicitly hide them from assistive technologies, leveraging MkDocs's `attr_list` extension.

--- a/docs/index.md
+++ b/docs/index.md
@@ -235,7 +235,7 @@ hide:
 ![Sustainable Urban Systems Lab logo](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
 ![Environmental Systems Lab logo](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
 <center markdown="1">
-:octicons-plus-24:
+:octicons-plus-24:{ aria-hidden="true" }
 </center>
 
 <br><br><br>


### PR DESCRIPTION
💡 **What:**
Added `aria-hidden="true"` to the `:octicons-plus-24:` emoji separating the two lab logos on the homepage (`docs/index.md`). Also documented this learning in `.Jules/palette.md`.

🎯 **Why:**
Screen readers will read out emojis and icons by their accessible name (e.g., "plus"). When an icon is purely decorative or used for layout purposes (like a visually pleasing separator between two items), this creates a redundant and confusing auditory experience for users. 

♿ **Accessibility:**
By using MkDocs's inline attribute list syntax (`{ aria-hidden="true" }`), the icon is explicitly hidden from assistive technologies while remaining visually present, significantly cleaning up the screen reader experience on the landing page.

---
*PR created automatically by Jules for task [800093590190918397](https://jules.google.com/task/800093590190918397) started by @kastnerp*