### PR TITLE
🎨 Palette: [Add aria-label to download page link]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2026-03-30 - [Descriptive Link Text for Raw URLs]
 **Learning:** Found a raw URL used directly in the `versions.md` changelog. Raw URLs are highly inaccessible to screen reader users because the screen reader will read out every single character of the URL (e.g., "h t t p s colon slash slash..."), which provides poor context and is frustrating to listen to.
 **Action:** When adding URLs to documentation or changelogs, always wrap them in descriptive text, such as `[Eddy3D Visualizer](https://eddy3d-dev.github.io/Eddy3D-Visualizer/)`, so the screen reader announces a human-readable title.
+
+## 2026-04-01 - [Contextualizing Generic Inline Links]
+**Learning:** Found an inline link in `docs/index.md` with the text "download page". While understandable in the surrounding paragraph context ("Latest stable release and pre-release builds are listed on the..."), out of context in a screen reader link list, "download page" might be slightly ambiguous compared to explicitly stating what is being downloaded.
+**Action:** When using generic phrasing like "download page" as link text within a paragraph, consider adding a descriptive `aria-label` (e.g., `aria-label="Go to the download page for Eddy3D releases"`) to ensure absolute clarity for screen reader users navigating out of context.

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,7 +106,7 @@ hide:
 </div>
 
 <p style="text-align: center; margin-top: 0.75rem;">
-  Latest stable release and pre-release builds are listed on the <a href="download/">download page</a>.
+  Latest stable release and pre-release builds are listed on the <a href="download/" aria-label="Go to the download page for Eddy3D releases">download page</a>.
 </p>
 
 


### PR DESCRIPTION
💡 What: Added an `aria-label` to the inline "download page" link in `docs/index.md`.
🎯 Why: "Download page" makes sense visually in context of the sentence, but for screen reader users navigating out-of-context via a links list, it is slightly ambiguous. The `aria-label` provides explicit context ("Go to the download page for Eddy3D releases").
📸 Before/After: Visuals are unchanged.
♿ Accessibility: Improves WCAG compliance for screen readers navigating via link lists out-of-context.

---
*PR created automatically by Jules for task [5727392893949275352](https://jules.google.com/task/5727392893949275352) started by @kastnerp*