### PR TITLE
🎨 Palette: Hide purely decorative emoji from screen readers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -235,7 +235,7 @@ hide:
 ![Sustainable Urban Systems Lab logo](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
 ![Environmental Systems Lab logo](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
 <center markdown="1">
-:octicons-plus-24:
+:octicons-plus-24:{ aria-hidden="true" }
 </center>
 
 <br><br><br>


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to the decorative plus icon on the index page.
🎯 **Why:** To improve accessibility by preventing screen readers from reading out the text representation of the decorative icon, which provides no meaningful content.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Prevents redundant or confusing audio announcements for screen reader users by hiding purely decorative inline emojis.

---
*PR created automatically by Jules for task [15016928790280203241](https://jules.google.com/task/15016928790280203241) started by @kastnerp*