### PR TITLE
🎨 Palette: Add aria-hidden to decorative inline emoji

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -56,3 +56,7 @@
 ## 2026-04-01 - [Contextualizing Generic Inline Links]
 **Learning:** Found an inline link in `docs/index.md` with the text "download page". While understandable in the surrounding paragraph context ("Latest stable release and pre-release builds are listed on the..."), out of context in a screen reader link list, "download page" might be slightly ambiguous compared to explicitly stating what is being downloaded.
 **Action:** When using generic phrasing like "download page" as link text within a paragraph, consider adding a descriptive `aria-label` (e.g., `aria-label="Go to the download page for Eddy3D releases"`) to ensure absolute clarity for screen reader users navigating out of context.
+
+## 2026-04-03 - [Decorative Inline Emojis Accessibility]
+**Learning:** In MkDocs, purely decorative inline emojis (like `:octicons-plus-24:`) are announced by screen readers, which can cause redundant or confusing audio clutter. Standard HTML attributes don't apply directly to the markdown shortcode.
+**Action:** Use MkDocs' inline attribute list syntax directly after the emoji shortcode (e.g., `:octicons-plus-24:{ aria-hidden="true" }`) to properly hide these decorative elements from assistive technologies.

--- a/docs/index.md
+++ b/docs/index.md
@@ -235,7 +235,7 @@ hide:
 ![Sustainable Urban Systems Lab logo](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
 ![Environmental Systems Lab logo](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
 <center markdown="1">
-:octicons-plus-24:
+:octicons-plus-24:{ aria-hidden="true" }
 </center>
 
 <br><br><br>


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to the decorative `:octicons-plus-24:` emoji in `docs/index.md`, and recorded this finding in Palette's journal.

🎯 **Why:** In MkDocs, inline emojis are announced by screen readers by default. For a purely decorative icon like a plus sign used for visual separation/layout, this creates confusing or redundant audio clutter.

♿ **Accessibility:** This ensures the decorative element is properly ignored by assistive technologies, providing a cleaner navigation experience for screen reader users.

---
*PR created automatically by Jules for task [3618477817397056038](https://jules.google.com/task/3618477817397056038) started by @kastnerp*