### PR TITLE
🎨 Palette: Add aria-labels to generic inline links for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,7 @@
 ## 2026-04-03 - [Decorative Inline Emojis Accessibility]
 **Learning:** In MkDocs, purely decorative inline emojis (like `:octicons-plus-24:`) are announced by screen readers, which can cause redundant or confusing audio clutter. Standard HTML attributes don't apply directly to the markdown shortcode.
 **Action:** Use MkDocs' inline attribute list syntax directly after the emoji shortcode (e.g., `:octicons-plus-24:{ aria-hidden="true" }`) to properly hide these decorative elements from assistive technologies.
+
+## 2026-04-04 - [Contextualizing Generic Links in Changelogs]
+**Learning:** Changelogs and release notes frequently contain repeating generic links like "compare on GitHub", "bug", or "issue". While visual users have context from the surrounding section or heading, screen reader users navigating via a link list lose this context entirely.
+**Action:** Always add descriptive `aria-label`s to generic links in changelogs (e.g., `[compare on GitHub](url){ aria-label="Compare version X to Y on GitHub" }`) using MkDocs' inline attribute list syntax to provide necessary context for screen reader users.

--- a/docs/download.md
+++ b/docs/download.md
@@ -11,7 +11,7 @@
 | Pre-release | `0.7.0-beta.827` | March 24, 2026 | Windows | 8.27 | [Install beta](https://rhinopackages.github.io/?search=eddy3d&sort=2&p=Eddy3D){ aria-label="Install Pre-release beta 0.7.0-beta.827" } | [Release notes](https://github.com/Eddy3D-Dev/Eddy3D/releases/tag/v0.7.0-beta.827){ aria-label="Pre-release beta 0.7.0-beta.827 release notes" } |
 | Stable release | `0.6.2.821` | February 11, 2026 | Windows | 8.27 | [Download stable](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ aria-label="Download Stable release 0.6.2.821" } | [Release notes](https://github.com/Eddy3D-Dev/Eddy3D/releases/tag/v0.6.2.821){ aria-label="Stable release 0.6.2.821 release notes" } |
 
-Depending on your use case, you may need additional software (BlueCFD, Radiance), [see documentation](https://docs.eddy3d.com).
+Depending on your use case, you may need additional software (BlueCFD, Radiance), [see documentation](https://docs.eddy3d.com){ aria-label="See documentation for additional software requirements" }.
 
 ---
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -16,7 +16,7 @@
 
 # Support
 
-We are currently collecting bugs and requests for new features on [Github](https://github.com/orgs/Eddy3D-Dev/discussions), where people help each other out with questions that go beyond our [Getting Started](https://docs.eddy3d.com) information. Please feel free to start a new thread if you have any questions.
+We are currently collecting bugs and requests for new features on [Github](https://github.com/orgs/Eddy3D-Dev/discussions){ aria-label="Visit Eddy3D GitHub Discussions" }, where people help each other out with questions that go beyond our [Getting Started](https://docs.eddy3d.com){ aria-label="Read Eddy3D Getting Started Documentation" } information. Please feel free to start a new thread if you have any questions.
 
 If your problem is urgent, please also notify us via e-mail as we are unable to monitor new posts 24/7.
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -12,7 +12,7 @@
 
 ### 0.7.0-beta.827 (March 24, 2026)
 
-Changes since `v0.6.2.821`: [compare on GitHub](https://github.com/Eddy3D-Dev/Eddy3D/compare/v0.6.2.821...v0.7.0-beta.827)
+Changes since `v0.6.2.821`: [compare on GitHub](https://github.com/Eddy3D-Dev/Eddy3D/compare/v0.6.2.821...v0.7.0-beta.827){ aria-label="Compare version 0.6.2.821 to 0.7.0-beta.827 on GitHub" }
 
 - Added:
 
@@ -47,7 +47,7 @@ Changes since `v0.6.2.821`: [compare on GitHub](https://github.com/Eddy3D-Dev/Ed
 
 ### 0.6.1.821 (February 10, 2026)
 
-Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Eddy3D/compare/v0.5.8.815...dev)
+Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Eddy3D/compare/v0.5.8.815...dev){ aria-label="Compare version 0.5.8.815 to dev on GitHub" }
 
 - Added:
 
@@ -237,8 +237,8 @@ Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Ed
 
 ### 0.4.15.8 (September 14, 2025)
 
-- Fixed: [issue #39](https://github.com/orgs/Eddy3D-Dev/discussions/39)
-- Added: [issue #35](https://github.com/orgs/Eddy3D-Dev/discussions/35)
+- Fixed: [issue #39](https://github.com/orgs/Eddy3D-Dev/discussions/39){ aria-label="View issue #39 on GitHub" }
+- Added: [issue #35](https://github.com/orgs/Eddy3D-Dev/discussions/35){ aria-label="View issue #35 on GitHub" }
 
 ### 0.4.15.7 (September 12, 2025)
 
@@ -275,7 +275,7 @@ Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Ed
 
 ### 0.4.15.3 (Mar 27, 2025)
 
-- Fixed [bug](https://github.com/orgs/Eddy3D-Dev/discussions/14#discussioncomment-12647741) in: `3_SimpleWindAnalysis.ghx` Template. Thank you `@YanivHatiel`
+- Fixed [bug](https://github.com/orgs/Eddy3D-Dev/discussions/14#discussioncomment-12647741){ aria-label="View bug discussion for 3_SimpleWindAnalysis on GitHub" } in: `3_SimpleWindAnalysis.ghx` Template. Thank you `@YanivHatiel`
 
 ### 0.4.15.2 (Mar 10, 2025)
 
@@ -302,7 +302,7 @@ Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Ed
 ### 0.4.2.0 (Dec 23, 2023)
 
 - Added: custom boundary conditions per individual wind direction.
-- Added alpha/experimental Rhino 8 compatibility. R8 introduces breaking changes, see [issue #9 on GitHub](https://github.com/EnvironmentalSystemsLab/Eddy3D-Public/issues/9).
+- Added alpha/experimental Rhino 8 compatibility. R8 introduces breaking changes, see [issue #9 on GitHub](https://github.com/EnvironmentalSystemsLab/Eddy3D-Public/issues/9){ aria-label="View issue #9 regarding Rhino 8 breaking changes on GitHub" }.
 
 ### 0.4.1.4 (Nov 23, 2023)
 
@@ -310,7 +310,7 @@ Changes since `v0.5.8.815`: [compare on GitHub](https://github.com/Eddy3D-Dev/Ed
 
 ### 0.4.1.1 (Apr 29, 2022)
 
-- New installer to fix BlueCFD 2017 [issue](https://github.com/EnvironmentalSystemsLab/Eddy3D-Public/issues/1) with Indoor module.
+- New installer to fix BlueCFD 2017 [issue](https://github.com/EnvironmentalSystemsLab/Eddy3D-Public/issues/1){ aria-label="View issue #1 regarding BlueCFD 2017 on GitHub" } with Indoor module.
 
 ### 0.4.1.0 (Apr 17, 2022)
 


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to generic inline links across `docs/support.md`, `docs/download.md`, and `docs/versions.md`.
🎯 **Why**: Generic link texts like "compare on GitHub", "bug", "issue", or "Getting Started" lack context when viewed outside of their surrounding paragraph or section. This creates a severe accessibility barrier for screen reader users who frequently navigate pages by pulling up a list of all links out of context. Adding a descriptive `aria-label` preserves the clean visual design while providing complete context to assistive technologies.
♿ **Accessibility**: Improved context for screen reader users navigating via a link list by turning ambiguous generic text into descriptive context.

I've also added a journal entry about contextualizing generic links in changelogs to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [13956169435781850256](https://jules.google.com/task/13956169435781850256) started by @kastnerp*