### PR TITLE
🎨 Palette: Hide decorative emojis from screen readers in headings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -68,3 +68,11 @@
 ## 2026-04-04 - [Contextualizing Generic Links in Changelogs]
 **Learning:** Changelogs and release notes frequently contain repeating generic links like "compare on GitHub", "bug", or "issue". While visual users have context from the surrounding section or heading, screen reader users navigating via a link list lose this context entirely.
 **Action:** Always add descriptive `aria-label`s to generic links in changelogs (e.g., `[compare on GitHub](url){ aria-label="Compare version X to Y on GitHub" }`) using MkDocs' inline attribute list syntax to provide necessary context for screen reader users.
+
+## 2026-04-12 - [Hide Decorative Emojis in Headings]
+**Learning:** Raw Unicode emojis in Markdown headers (like ) are read aloud by screen readers, creating redundant and confusing audio clutter when they are purely decorative.
+**Action:** Always replace raw Unicode emojis in headings with MkDocs shortcodes and append the inline attribute syntax  (e.g., ) to ensure they are hidden from assistive technologies while remaining visually identical.
+
+## 2026-04-12 - [Hide Decorative Emojis in Headings]
+**Learning:** Raw Unicode emojis in Markdown headers (like `## 🚀 Features`) are read aloud by screen readers, creating redundant and confusing audio clutter when they are purely decorative.
+**Action:** Always replace raw Unicode emojis in headings with MkDocs shortcodes and append the inline attribute syntax `{ aria-hidden="true" }` (e.g., `## :rocket:{ aria-hidden="true" } Features`) to ensure they are hidden from assistive technologies while remaining visually identical.

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,7 @@ hide:
 
 ---
 
-## 🚀 Features
+## :rocket:{ aria-hidden="true" } Features
 
 <div class="grid cards" markdown>
 
@@ -169,7 +169,7 @@ hide:
 
 ---
 
-## 👥 Team
+## :busts_in_silhouette:{ aria-hidden="true" } Team
 
 
 <div class="mdx-users">
@@ -209,7 +209,7 @@ hide:
 
 </div>
 
-## 👥 Advisors & Alumni 
+## :busts_in_silhouette:{ aria-hidden="true" } Advisors & Alumni
 
 <div class="mdx-users">
 
@@ -244,7 +244,7 @@ Eddy3D is being developed as a cross-disciplinary project through a collaboratio
 
 ---
 
-## 🎉 Supporters
+## :tada:{ aria-hidden="true" } Supporters
 
 <div class="grid" markdown>
 


### PR DESCRIPTION
💡 What: Replaced raw Unicode emojis in headings with MkDocs shortcodes and added `aria-hidden="true"`.
🎯 Why: Raw emojis are announced by screen readers, creating redundant or confusing audio clutter before the actual heading text. Hiding them creates a cleaner experience for users relying on assistive technology.
♿ Accessibility: Improved screen reader navigation flow by preventing the announcement of decorative header icons.

---
*PR created automatically by Jules for task [8041114465819736055](https://jules.google.com/task/8041114465819736055) started by @kastnerp*