### PR TITLE
🔒 Pin Docker base image to prevent unpredictable builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material
+FROM squidfunk/mkdocs-material:9.7.6
 
 # ---- system packages ----------------------------------------------------
 RUN apk add --no-cache \


### PR DESCRIPTION
🎯 **What:** Pinned the `squidfunk/mkdocs-material` base image in the Dockerfile to version `9.7.6`.
⚠️ **Risk:** Relying on the implicit `latest` tag can lead to unpredictable builds and potential security issues if a compromised or backwards-incompatible image is pulled automatically.
🛡️ **Solution:** Explicitly pinning the version to `9.7.6` ensures that builds remain reproducible and secure over time, mitigating the risk of pulling an untrusted version.

---
*PR created automatically by Jules for task [14239593974055849750](https://jules.google.com/task/14239593974055849750) started by @kastnerp*