### PR TITLE
🧹 Remove commented-out repo_url and edit_uri from mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,6 @@
 site_name: Eddy3D
 site_description: 'Airflow and microclimate simulations for Rhino and Grasshopper'
 site_url: https://eddy3d.com
-# repo_url: https://github.com/Eddy3D-Dev/Eddy3D-Website
-# edit_uri: blob/main/docs/
 site_author: Patrick Kastner
 copyright: >-
   Copyright &copy; 2018-2026 Eddy3D


### PR DESCRIPTION
🎯 **What:** Removed commented-out `repo_url` and `edit_uri` settings from `mkdocs.yml`.
💡 **Why:** These were dead code taking up space and potentially causing confusion. Removing them improves code readability.
✅ **Verification:** Verified that the mkdocs build continues to succeed using `mkdocs build`.
✨ **Result:** A cleaner configuration file.

---
*PR created automatically by Jules for task [961345717417476917](https://jules.google.com/task/961345717417476917) started by @kastnerp*