### PR TITLE
🧹 Code Health: Remove commented-out CSS rule in extra.css

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -12,7 +12,6 @@ span.em {
 
 a.field {
   font-weight: 600;
-  /* color: #3c4257; */
   font-size: .8rem;
 }
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out CSS rule `/* color: #3c4257; */` in `docs/stylesheets/extra.css`.
💡 **Why:** To improve code maintainability and remove dead code.
✅ **Verification:** Verified by building the MkDocs project locally via `mkdocs build`. The site built successfully without introducing visual or compilation regressions.
✨ **Result:** A cleaner CSS file with no commented-out code.

---
*PR created automatically by Jules for task [408611677491995329](https://jules.google.com/task/408611677491995329) started by @kastnerp*