### PR TITLE
🧹 Centralize inline .md-content__button styling to extra.css

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -38,9 +38,6 @@ Use the [**Rhino version selection page**](https://rhinoversions.github.io/?vers
         display: none;
       }
     }
-    .md-content__button {
-      display: none;
-    }
     /* Keep only top 2 levels in the right TOC */
     .md-sidebar--secondary .md-nav__list .md-nav__list { display: none; }
 </style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,6 @@ hide:
 ---
 
 <style>
-.md-content__button {
-    display: none;
-}
 .md-button {
   font-size: 16px;
   font-weight: bold;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -46,3 +46,7 @@ span.faint {
 [data-md-color-scheme="slate"] .hero-logo__image {
   filter: brightness(0) invert(0.86);
 }
+
+.md-content__button {
+  display: none;
+}

--- a/docs/support.md
+++ b/docs/support.md
@@ -9,9 +9,6 @@
         display: none;
       }
     }
-      .md-content__button {
-    display: none;
-  }
 </style>
 
 # Support


### PR DESCRIPTION
🎯 **What:** Removed repeated inline CSS for `.md-content__button { display: none; }` from `docs/index.md`, `docs/download.md`, and `docs/support.md`, and centralized it in `docs/stylesheets/extra.css`.

💡 **Why:** Moving repeated inline styles to the central `extra.css` file reduces duplication and improves maintainability of the codebase.

✅ **Verification:** Ran `mkdocs build` to confirm the site builds correctly, wrote and executed a Playwright script to visually verify that the button remains hidden as expected, and ran `npx jest` to ensure tests are passing.

✨ **Result:** Cleaned up documentation files by removing redundant styling blocks, leading to a more maintainable and consistent codebase.

---
*PR created automatically by Jules for task [7982772117967632385](https://jules.google.com/task/7982772117967632385) started by @kastnerp*