### PR TITLE
🎨 Palette: Remove redundant alt text from images

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -76,3 +76,11 @@
 ## 2026-04-12 - [Hide Decorative Emojis in Headings]
 **Learning:** Raw Unicode emojis in Markdown headers (like `## 🚀 Features`) are read aloud by screen readers, creating redundant and confusing audio clutter when they are purely decorative.
 **Action:** Always replace raw Unicode emojis in headings with MkDocs shortcodes and append the inline attribute syntax `{ aria-hidden="true" }` (e.g., `## :rocket:{ aria-hidden="true" } Features`) to ensure they are hidden from assistive technologies while remaining visually identical.
+
+## 2026-05-08 - [Redundant "Logo" in Alt Text]
+**Learning:** Screen readers typically announce images as "image" or "graphic". Including words like "logo" or "image" in the `alt` text causes redundant and repetitive announcements (e.g., "Cornell University logo image").
+**Action:** Avoid using words like "logo", "image", or "picture" in the `alt` text. Simply describe the content or entity (e.g., `![Cornell University]`).
+
+## 2026-05-08 - [Redundant Alt Text in Feature Cards]
+**Learning:** When an image in a feature card is immediately followed by text that perfectly describes its content or purpose, providing a descriptive `alt` text causes the screen reader to read the same information twice, resulting in a poor user experience.
+**Action:** Use an empty `alt` attribute (`![]` or `alt=""`) for images in feature cards or lists where the adjacent visible text already provides a full and accurate description of the image.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hide:
 # Eddy3D {.sr-only}
 
 <figure class="hero-logo" markdown="span">
-  ![Eddy3D Logo](assets/cd/LogoEddy-01_preview-crop.png){ width="250" .skip-lightbox .hero-logo__image }
+  ![](assets/cd/LogoEddy-01_preview-crop.png){ width="250" .skip-lightbox .hero-logo__image }
 </figure>
 
 <p style="text-align: center; font-size: 24px;">
@@ -34,7 +34,7 @@ hide:
 
 <div class="grid cards" markdown>
 
--   ![Clean user interface for urban wind flow analysis](assets/images/asset_18.png){ width="300" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_18.png){ width="300" loading=lazy .skip-lightbox  .center}
 
     ---
 
@@ -42,7 +42,7 @@ hide:
     
     Clean and easy-to-use UI for urban wind flow analysis.
 
--   ![Realistic terrain rendering for simulation setups](assets/images/asset_19.png){ width="255" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_19.png){ width="255" loading=lazy .skip-lightbox  .center}
 
     ---
 
@@ -50,14 +50,14 @@ hide:
 
     Add realistic terrain to your simulation setup.
 
--   ![Annual outdoor thermal comfort assessment map](assets/images/asset_31.png){ width="410" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_31.png){ width="410" loading=lazy .skip-lightbox  .center}
 
     ---
     __OUTDOOR THERMAL COMFORT__
 
     Annual outdoor thermal comfort assessment for climate-responsive masterplanning.
  
--   ![Post-processing of custom surfaces for EnergyPlus integration](assets/images/asset_25.png){ width="300" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_25.png){ width="300" loading=lazy .skip-lightbox  .center}
      
 
     ---
@@ -65,7 +65,7 @@ hide:
 
     Post-processing of custom surfaces for Air Flow Network integration into EnergyPlus.
   
--   ![Urban turntable visualization for fast airflow analysis](assets/images/asset_22.png){ width="350" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_22.png){ width="350" loading=lazy .skip-lightbox  .center}
     
 
     ---
@@ -73,7 +73,7 @@ hide:
 
     Urban turntable for fast outdoor airflow analysis.
 
--   ![Validated simulation engine showing accurate computational results](assets/images/asset_29.png){ width="450" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_29.png){ width="450" loading=lazy .skip-lightbox  .center}
     
 
     ---
@@ -150,8 +150,8 @@ hide:
 
 ---
 
-![Sustainable Urban Systems Lab logo](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
-![Environmental Systems Lab logo](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
+![Sustainable Urban Systems Lab](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
+![Environmental Systems Lab](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
 <center markdown="1">
 :octicons-plus-24:{ aria-hidden="true" }
 </center>
@@ -166,22 +166,22 @@ Eddy3D is being developed as a cross-disciplinary project through a collaboratio
 
 <div class="grid" markdown>
 
-![Georgia Tech School of Architecture logo](assets/images/CoD_SoA.jpg){width="250" .skip-lightbox loading=lazy .center}
+![Georgia Tech School of Architecture](assets/images/CoD_SoA.jpg){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Georgia Tech logo](assets/images/GeorgiaTech_RGB.png){width="250" .skip-lightbox loading=lazy .center}
+![Georgia Tech](assets/images/GeorgiaTech_RGB.png){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell AAP logo](assets/images/AAP_logo_stacked.png){width="75" .skip-lightbox loading=lazy .center}
+![Cornell AAP](assets/images/AAP_logo_stacked.png){width="75" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell University logo](assets/images/cornell.svg){width="75" .skip-lightbox loading=lazy .center}
+![Cornell University](assets/images/cornell.svg){width="75" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell Atkinson Center for Sustainability logo](assets/images/atkinson.png){width="200" .skip-lightbox loading=lazy .center}
+![Cornell Atkinson Center for Sustainability](assets/images/atkinson.png){width="200" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell Systems Engineering logo](assets/images/logo-systemseng.svg){width="250" .skip-lightbox loading=lazy .center}
+![Cornell Systems Engineering](assets/images/logo-systemseng.svg){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
 </div>


### PR DESCRIPTION
💡 What: The UX enhancement added is cleaning up redundant alt text in `docs/index.md`. Feature card images now have empty alt text `![]` since the description beneath them describes the feature perfectly. Support and lab logo images had the word "logo" removed.
🎯 Why: Screen readers automatically prepend or append "image" or "graphic" when reading image alt text, so having "logo" causes redundant reading ("Cornell University logo image"). Feature card images having descriptive alt text resulted in the screen reader reciting the exact same information right afterwards because of the description directly underneath.
♿ Accessibility: This change directly improves the user experience for visually impaired users relying on screen readers.

---
*PR created automatically by Jules for task [2016448049278960932](https://jules.google.com/task/2016448049278960932) started by @kastnerp*