### PR TITLE
🎨 Palette: remove redundant words from image alt text

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -76,3 +76,7 @@
 ## 2026-04-12 - [Hide Decorative Emojis in Headings]
 **Learning:** Raw Unicode emojis in Markdown headers (like `## 🚀 Features`) are read aloud by screen readers, creating redundant and confusing audio clutter when they are purely decorative.
 **Action:** Always replace raw Unicode emojis in headings with MkDocs shortcodes and append the inline attribute syntax `{ aria-hidden="true" }` (e.g., `## :rocket:{ aria-hidden="true" } Features`) to ensure they are hidden from assistive technologies while remaining visually identical.
+
+## 2026-05-09 - [Redundant Alt Text]
+**Learning:** Screen readers automatically announce images as "image" or "graphic". Including words like "logo", "image", or "picture" in the `alt` text causes the screen reader to say "logo image", which is redundant and adds unnecessary audio clutter.
+**Action:** Never use words like "logo", "image", or "picture" in image `alt` text. Provide a concise description of the content or function (e.g., use `![Cornell University]` instead of `![Cornell University logo]`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hide:
 # Eddy3D {.sr-only}
 
 <figure class="hero-logo" markdown="span">
-  ![Eddy3D Logo](assets/cd/LogoEddy-01_preview-crop.png){ width="250" .skip-lightbox .hero-logo__image }
+  ![Eddy3D](assets/cd/LogoEddy-01_preview-crop.png){ width="250" .skip-lightbox .hero-logo__image }
 </figure>
 
 <p style="text-align: center; font-size: 24px;">
@@ -150,8 +150,8 @@ hide:
 
 ---
 
-![Sustainable Urban Systems Lab logo](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
-![Environmental Systems Lab logo](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
+![Sustainable Urban Systems Lab](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
+![Environmental Systems Lab](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
 <center markdown="1">
 :octicons-plus-24:{ aria-hidden="true" }
 </center>
@@ -166,22 +166,22 @@ Eddy3D is being developed as a cross-disciplinary project through a collaboratio
 
 <div class="grid" markdown>
 
-![Georgia Tech School of Architecture logo](assets/images/CoD_SoA.jpg){width="250" .skip-lightbox loading=lazy .center}
+![Georgia Tech School of Architecture](assets/images/CoD_SoA.jpg){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Georgia Tech logo](assets/images/GeorgiaTech_RGB.png){width="250" .skip-lightbox loading=lazy .center}
+![Georgia Tech](assets/images/GeorgiaTech_RGB.png){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell AAP logo](assets/images/AAP_logo_stacked.png){width="75" .skip-lightbox loading=lazy .center}
+![Cornell AAP](assets/images/AAP_logo_stacked.png){width="75" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell University logo](assets/images/cornell.svg){width="75" .skip-lightbox loading=lazy .center}
+![Cornell University](assets/images/cornell.svg){width="75" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell Atkinson Center for Sustainability logo](assets/images/atkinson.png){width="200" .skip-lightbox loading=lazy .center}
+![Cornell Atkinson Center for Sustainability](assets/images/atkinson.png){width="200" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell Systems Engineering logo](assets/images/logo-systemseng.svg){width="250" .skip-lightbox loading=lazy .center}
+![Cornell Systems Engineering](assets/images/logo-systemseng.svg){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
 </div>


### PR DESCRIPTION
💡 **What**: Removed redundant words like "logo" and "Logo" from image `alt` texts on the homepage (`docs/index.md`). Added a learning journal entry about this accessibility pattern.
🎯 **Why**: Screen readers inherently announce images as "image" or "graphic". When "logo" or "image" is manually appended to the `alt` text (e.g., `alt="Cornell University logo"`), it causes screen readers to redundantly announce "Cornell University logo image", creating unnecessary audio clutter.
♿ **Accessibility**: Reduces redundant screen reader announcements, making the page more efficiently navigable for non-visual users.

---
*PR created automatically by Jules for task [9221220676558572671](https://jules.google.com/task/9221220676558572671) started by @kastnerp*