### PR TITLE
🎨 Palette: Remove redundant image alt text for better screen reader experience

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -76,3 +76,7 @@
 ## 2026-04-12 - [Hide Decorative Emojis in Headings]
 **Learning:** Raw Unicode emojis in Markdown headers (like `## 🚀 Features`) are read aloud by screen readers, creating redundant and confusing audio clutter when they are purely decorative.
 **Action:** Always replace raw Unicode emojis in headings with MkDocs shortcodes and append the inline attribute syntax `{ aria-hidden="true" }` (e.g., `## :rocket:{ aria-hidden="true" } Features`) to ensure they are hidden from assistive technologies while remaining visually identical.
+
+## 2026-04-14 - [Redundant Alt Text in Feature Grids]
+**Learning:** In `docs/index.md`'s `## Features` section, images were used alongside highly descriptive adjacent text. Having alt text on these images causes screen readers to read the same information twice. Additionally, images of logos often contain "logo" in their alt text (e.g., "Cornell University logo"). Screen readers already announce the element as an image, so including "logo" results in redundant announcements like "Image, Cornell University logo".
+**Action:** Always set the alt attribute to empty (e.g., `alt=""` or `![]`) when an image is immediately followed by text that perfectly describes its content. Furthermore, never include words like "logo", "image", or "picture" in the alt text to avoid redundant announcements by screen readers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hide:
 # Eddy3D {.sr-only}
 
 <figure class="hero-logo" markdown="span">
-  ![Eddy3D Logo](assets/cd/LogoEddy-01_preview-crop.png){ width="250" .skip-lightbox .hero-logo__image }
+  ![Eddy3D](assets/cd/LogoEddy-01_preview-crop.png){ width="250" .skip-lightbox .hero-logo__image }
 </figure>
 
 <p style="text-align: center; font-size: 24px;">
@@ -34,7 +34,7 @@ hide:
 
 <div class="grid cards" markdown>
 
--   ![Clean user interface for urban wind flow analysis](assets/images/asset_18.png){ width="300" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_18.png){ width="300" loading=lazy .skip-lightbox  .center}
 
     ---
 
@@ -42,7 +42,7 @@ hide:
     
     Clean and easy-to-use UI for urban wind flow analysis.
 
--   ![Realistic terrain rendering for simulation setups](assets/images/asset_19.png){ width="255" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_19.png){ width="255" loading=lazy .skip-lightbox  .center}
 
     ---
 
@@ -50,14 +50,14 @@ hide:
 
     Add realistic terrain to your simulation setup.
 
--   ![Annual outdoor thermal comfort assessment map](assets/images/asset_31.png){ width="410" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_31.png){ width="410" loading=lazy .skip-lightbox  .center}
 
     ---
     __OUTDOOR THERMAL COMFORT__
 
     Annual outdoor thermal comfort assessment for climate-responsive masterplanning.
  
--   ![Post-processing of custom surfaces for EnergyPlus integration](assets/images/asset_25.png){ width="300" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_25.png){ width="300" loading=lazy .skip-lightbox  .center}
      
 
     ---
@@ -65,7 +65,7 @@ hide:
 
     Post-processing of custom surfaces for Air Flow Network integration into EnergyPlus.
   
--   ![Urban turntable visualization for fast airflow analysis](assets/images/asset_22.png){ width="350" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_22.png){ width="350" loading=lazy .skip-lightbox  .center}
     
 
     ---
@@ -73,7 +73,7 @@ hide:
 
     Urban turntable for fast outdoor airflow analysis.
 
--   ![Validated simulation engine showing accurate computational results](assets/images/asset_29.png){ width="450" loading=lazy .skip-lightbox  .center}
+-   ![](assets/images/asset_29.png){ width="450" loading=lazy .skip-lightbox  .center}
     
 
     ---
@@ -150,8 +150,8 @@ hide:
 
 ---
 
-![Sustainable Urban Systems Lab logo](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
-![Environmental Systems Lab logo](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
+![Sustainable Urban Systems Lab](assets/images/SustainLab.svg){width="350" .skip-lightbox align=left loading=lazy}
+![Environmental Systems Lab](assets/images/eslab.svg){width="320" .skip-lightbox align=right loading=lazy}
 <center markdown="1">
 :octicons-plus-24:{ aria-hidden="true" }
 </center>
@@ -166,22 +166,22 @@ Eddy3D is being developed as a cross-disciplinary project through a collaboratio
 
 <div class="grid" markdown>
 
-![Georgia Tech School of Architecture logo](assets/images/CoD_SoA.jpg){width="250" .skip-lightbox loading=lazy .center}
+![Georgia Tech School of Architecture](assets/images/CoD_SoA.jpg){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Georgia Tech logo](assets/images/GeorgiaTech_RGB.png){width="250" .skip-lightbox loading=lazy .center}
+![Georgia Tech](assets/images/GeorgiaTech_RGB.png){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell AAP logo](assets/images/AAP_logo_stacked.png){width="75" .skip-lightbox loading=lazy .center}
+![Cornell AAP](assets/images/AAP_logo_stacked.png){width="75" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell University logo](assets/images/cornell.svg){width="75" .skip-lightbox loading=lazy .center}
+![Cornell University](assets/images/cornell.svg){width="75" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell Atkinson Center for Sustainability logo](assets/images/atkinson.png){width="200" .skip-lightbox loading=lazy .center}
+![Cornell Atkinson Center for Sustainability](assets/images/atkinson.png){width="200" .skip-lightbox loading=lazy .center}
 { .card }
 
-![Cornell Systems Engineering logo](assets/images/logo-systemseng.svg){width="250" .skip-lightbox loading=lazy .center}
+![Cornell Systems Engineering](assets/images/logo-systemseng.svg){width="250" .skip-lightbox loading=lazy .center}
 { .card }
 
 </div>


### PR DESCRIPTION
This PR improves the screen reader experience on the landing page by addressing redundant image alt text.

*   **Removed "logo" from alt attributes:** Screen readers naturally announce an element as an image, so alt text like "Cornell University logo" results in redundant and annoying read-outs like "Image, Cornell University logo". This was removed from all sponsor and partner logos.
*   **Cleared alt text in Feature Cards:** The images in the `## Features` grid are immediately followed by text that perfectly describes their content. Giving the image alt text caused the screen reader to read the exact same information twice. Setting the alt attribute to empty (via `![]()`) tells screen readers to skip the decorative image and move directly to the descriptive text.
*   **Journal Updated:** Added an entry to `.Jules/palette.md` to document this accessibility learning for future reference.

---
*PR created automatically by Jules for task [6128686286356918839](https://jules.google.com/task/6128686286356918839) started by @kastnerp*